### PR TITLE
chore(security): harden CI, Dockerfile, and bump 3-year-old deps

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,6 +1,8 @@
 ---
 name: "push"
 
+permissions: {}
+
 on:
   release:
     types:
@@ -10,22 +12,27 @@ jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Check Out Repo 
-        uses: actions/checkout@v2
+      - name: Check Out Repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: "Setup buildx"
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: "Login into ghcr"
-        uses: docker/login-action@v1
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Build image"
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.8-slim-buster
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
 
 WORKDIR /app
 
 COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY github-traffic.py /app/github-traffic.py
+
+RUN useradd -u 1001 -m -s /sbin/nologin app
+USER app
 
 CMD [ "python3", "github-traffic.py"]

--- a/github-traffic.py
+++ b/github-traffic.py
@@ -1,10 +1,8 @@
-from github import Github
+from github import Auth, Github
 from decouple import config
 from prometheus_client import start_http_server, Gauge
-from decouple import config
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
-from prometheus_client import start_http_server, Gauge
 from logfmt_logger import getLogger
 
 ORG_NAME = config("ORG_NAME", default="")
@@ -14,7 +12,7 @@ REPO_NAME_CONTAINS = config("REPO_NAME_CONTAINS", default="")
 CRONTAB_SCHEDULE = config("CRONTAB_SCHEDULE", default="0 * * * *")
 GITHUB_TOKEN = config('GITHUB_TOKEN')
 
-github = Github(GITHUB_TOKEN)
+github = Github(auth=Auth.Token(GITHUB_TOKEN))
 
 logger = getLogger("github_traffic")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-apscheduler==3.7.0
-requests==2.25.0
-python-decouple==3.3
-prometheus-client==0.9.0
-pygithub==1.51
-logfmt-logger==0.1.2 
+apscheduler==3.11.2
+requests==2.34.2
+python-decouple==3.8
+prometheus-client==0.25.0
+pygithub==2.9.1
+logfmt-logger==0.1.2


### PR DESCRIPTION
## Summary

Apply Grafana security-week hardening guidelines.

### CI workflow (`push.yaml`)
- Add top-level `permissions: {}` and per-job least-privilege (`contents: read`, `packages: write` — just what's needed for the ghcr push)
- SHA-pin all third-party actions with version comments:
  - `actions/checkout@v2` (5 years old) → `v4.3.1`
  - `docker/setup-buildx-action@v1` → `v3.12.0`
  - `docker/login-action@v1` → `v3.7.0`
  - `docker/build-push-action@v2` → `v6.19.2`
- Add `persist-credentials: false` to checkout

### Dockerfile
- Bump `python:3.8-slim-buster` → `python:3.12-slim` (**Python 3.8 reached EOL in Oct 2024; Debian buster is also EOL**)
- SHA-pin the base image
- Add `--no-cache-dir` to `pip install` (smaller image)
- Run as **non-root** user (uid 1001)

### `requirements.txt` (deps were 3.5–4 years old, with known CVEs)
- `apscheduler` 3.7.0 → 3.11.2
- `requests` 2.25.0 → 2.34.2 (fixes [CVE-2024-35195](https://github.com/advisories/GHSA-9wx4-h78v-vm56) and others)
- `python-decouple` 3.3 → 3.8
- `prometheus-client` 0.9.0 → 0.25.0
- `pygithub` 1.51 → 2.9.1

### `github-traffic.py`
- Switch to PyGithub 2.x auth API (`Github(auth=Auth.Token(token))`) to clear `DeprecationWarning`
- De-duplicate redundant `from decouple` / `from prometheus_client` imports

## Test plan
- [x] `docker build` succeeds with the updated Dockerfile
- [x] `python3 -c "from github import Auth, Github; Github(auth=Auth.Token('t'))"` works inside the built image with no deprecation warning
- [ ] CI passes on this PR